### PR TITLE
delete USECYCLUS for cycamore archetypes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,28 +5,6 @@ CONFIGURE_FILE(recycle_version.h.in "${CMAKE_CURRENT_SOURCE_DIR}/recycle_version
 
 SET(CYCLUS_CUSTOM_HEADERS "recycle_version.h")
 
-USE_CYCLUS("recycle" "reactor")
-
-USE_CYCLUS("recycle" "fuel_fab")
-
-USE_CYCLUS("recycle" "mixer")
-
-USE_CYCLUS("recycle" "enrichment")
-
-USE_CYCLUS("recycle" "separations")
-
-USE_CYCLUS("recycle" "sink")
-
-USE_CYCLUS("recycle" "source")
-
-USE_CYCLUS("recycle" "deploy_inst")
-
-USE_CYCLUS("recycle" "manager_inst")
-
-USE_CYCLUS("recycle" "growth_region")
-
-USE_CYCLUS("recycle" "storage")
-
 INSTALL_CYCLUS_MODULE("recycle" "" "NONE")
 
 SET(TestSource ${recycle_TEST_CC} PARENT_SCOPE)

--- a/src/recycle.h
+++ b/src/recycle.h
@@ -3,20 +3,4 @@
 
 #include "recycle_version.h"
 
-#include "batch_reactor.h"
-#include "batch_reactor_tests.h"
-#include "deploy_inst.h"
-#include "enrichment.h"
-#include "enrichment_tests.h"
-#include "growth_region.h"
-#include "growth_region_tests.h"
-#include "inpro_reactor.h"
-#include "inpro_reactor_tests.h"
-#include "manager_inst.h"
-#include "manager_inst_tests.h"
-#include "sink.h"
-#include "sink_tests.h"
-#include "source.h"
-#include "source_tests.h"
-
 #endif  // RECYCLE_SRC_RECYCLE_H_


### PR DESCRIPTION
since we are deleting the cycamore archetype files, we don't want the build to fail because of that.