### PR TITLE
remove libxml++ and capitalize SQLite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,17 +114,6 @@ IF(NOT CYCLUS_DOC_ONLY)
     # Include macros installed with cyclus core
     INCLUDE(UseCyclus)
 
-    # Find LibXML++ and dependencies
-    FIND_PACKAGE(LibXML++)
-    IF(NOT LibXML++_LIBRARIES)
-        FIND_LIBRARY(LibXML++ REQUIRED ${DEPS_HINTS})
-    ENDIF()
-    SET(RECYCLE_INCLUDE_DIRS ${RECYCLE_INCLUDE_DIRS} ${LibXML++_INCLUDE_DIR} ${Glibmm_INCLUDE_DIRS} ${LibXML++Config_INCLUDE_DIR})
-    SET(LIBS ${LIBS} ${LibXML++_LIBRARIES})
-    MESSAGE("-- LIBS: ${LIBS}")
-
-    MESSAGE("-- LD_LIBRARY_PATH: $ENV{LD_LIBRARY_PATH}")
-
     # Include the boost header files and the program_options library
     # Please be sure to use Boost rather than BOOST.
     # Capitalization matters on some platforms
@@ -181,7 +170,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     MESSAGE("--    COIN Include directories: ${COIN_INCLUDE_DIRS}")
     MESSAGE("--    COIN Libraries: ${COIN_LIBRARIES}")
 
-    FIND_PACKAGE( Sqlite3 REQUIRED )
+    FIND_PACKAGE( SQLite3 REQUIRED )
     SET(RECYCLE_INCLUDE_DIRS ${RECYCLE_INCLUDE_DIRS} ${SQLITE3_INCLUDE_DIR})
     SET(LIBS ${LIBS} ${SQLITE3_LIBRARIES})
     MESSAGE("--    SQLITE3 Include directories: ${SQLITE3_INCLUDE_DIR}")


### PR DESCRIPTION
This pull request changes the CMakeLists.txt file in [recycle](https://github.com/cyclus/recycle/) to match the changes to the same file in in [cycamore](https://github.com/cyclus/cycamore). The install file runs while using Cyclus v1.6.0 with these edits.

I've found that `python install.py --clean_build -DCMAKE_CXX_STANDARD=14` builds reliably.